### PR TITLE
chore: add postcss config for tailwind v3

### DIFF
--- a/aurelia-mockup-generator/client/package.json
+++ b/aurelia-mockup-generator/client/package.json
@@ -15,7 +15,7 @@
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11",
+    "tailwindcss": "^3.4.4",
     "vite": "^4.4.9"
   }
 }

--- a/aurelia-mockup-generator/client/postcss.config.js
+++ b/aurelia-mockup-generator/client/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/aurelia-mockup-generator/client/tailwind.config.js
+++ b/aurelia-mockup-generator/client/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- downgrade client Tailwind CSS to v3
- add PostCSS and Tailwind configs under client

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*
- `npm run build` *(fails: looks like you're trying to use `tailwindcss` directly as a PostCSS plugin)*


------
https://chatgpt.com/codex/tasks/task_e_689557365f3083208e664b388aff5f83