### PR TITLE
Ensure Replicate credentials are required

### DIFF
--- a/aurelia-mockup-generator/Dockerfile
+++ b/aurelia-mockup-generator/Dockerfile
@@ -23,5 +23,8 @@ COPY --from=frontend /app/client/dist ./client/dist
 WORKDIR /app/server
 ENV NODE_ENV=production
 ENV PORT=3000
+# Required environment variables
+ENV REPLICATE_API_TOKEN=""
+ENV REPLICATE_MODEL_VERSION=""
 EXPOSE 3000
 CMD ["node", "index.js"]

--- a/aurelia-mockup-generator/server/index.js
+++ b/aurelia-mockup-generator/server/index.js
@@ -17,11 +17,14 @@ const REPLICATE_API_TOKEN = process.env.REPLICATE_API_TOKEN;
 const REPLICATE_MODEL_VERSION = process.env.REPLICATE_MODEL_VERSION; // <-- real version hash
 const PORT = process.env.PORT || 3000;
 
-if (!REPLICATE_API_TOKEN) {
-  console.warn('⚠️  Missing REPLICATE_API_TOKEN');
-}
-if (!REPLICATE_MODEL_VERSION) {
-  console.warn('⚠️  Missing REPLICATE_MODEL_VERSION');
+const missingEnv = [];
+if (!REPLICATE_API_TOKEN) missingEnv.push('REPLICATE_API_TOKEN');
+if (!REPLICATE_MODEL_VERSION) missingEnv.push('REPLICATE_MODEL_VERSION');
+if (missingEnv.length) {
+  console.error(
+    `❌ Missing required environment variables: ${missingEnv.join(', ')}`
+  );
+  process.exit(1);
 }
 
 const MOCKUP_CONFIG = JSON.parse(
@@ -149,9 +152,11 @@ app.get('/progress/:id', (req, res) => {
 // ---------- Generate route ----------
 app.post('/generate', upload.single('artwork'), async (req, res) => {
   if (!REPLICATE_API_TOKEN || !REPLICATE_MODEL_VERSION) {
+    const missing = [];
+    if (!REPLICATE_API_TOKEN) missing.push('REPLICATE_API_TOKEN');
+    if (!REPLICATE_MODEL_VERSION) missing.push('REPLICATE_MODEL_VERSION');
     return res.status(500).json({
-      error:
-        'Server missing Replicate configuration. Set REPLICATE_API_TOKEN and REPLICATE_MODEL_VERSION.',
+      error: `Server missing required environment variables: ${missing.join(', ')}`,
     });
   }
 


### PR DESCRIPTION
## Summary
- exit server on startup if `REPLICATE_API_TOKEN` or `REPLICATE_MODEL_VERSION` are missing
- `/generate` route returns explicit error if Replicate credentials are not configured
- Dockerfile documents required Replicate environment variables

## Testing
- `npm test` *(fails: Missing script "test" with no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6895589d9dfc8320ad382c2561a6e530