### PR TITLE
chore: verify client build artifacts

### DIFF
--- a/aurelia-mockup-generator/Dockerfile
+++ b/aurelia-mockup-generator/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/client
 COPY client/package*.json ./
 RUN npm install
 COPY client/ .
-RUN npm run build
+RUN npm run build && test -f dist/index.html
 
 # ---------- BACKEND BUILD ----------
 FROM node:18-alpine AS backend
@@ -18,6 +18,7 @@ COPY mockups.json .
 
 # Copy built frontend into backend's static folder
 COPY --from=frontend /app/client/dist ./client/dist
+RUN test -f client/dist/index.html
 
 # ---------- RUN APP ----------
 WORKDIR /app/server


### PR DESCRIPTION
## Summary
- ensure Docker build produces client/dist with index.html
- fail Docker build if built assets are missing

## Testing
- `npm install --include=dev`
- `npm run build`
- `docker build -t mockup-app aurelia-mockup-generator` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6895589cf41483208c9e8f7664cb6937