### PR TITLE
Handle uploaded artwork and pass to Replicate

### DIFF
--- a/aurelia-mockup-generator/client/src/App.jsx
+++ b/aurelia-mockup-generator/client/src/App.jsx
@@ -4,6 +4,7 @@ export default function App() {
   const [file, setFile] = useState(null);
   const [title, setTitle] = useState('');
   const [collection, setCollection] = useState('');
+  const [imageMode, setImageMode] = useState('');
   const [loading, setLoading] = useState(false);
   const [previews, setPreviews] = useState([]);
   const [downloadUrl, setDownloadUrl] = useState(null);
@@ -28,6 +29,7 @@ export default function App() {
     formData.append('artwork', file);
     formData.append('title', title);
     formData.append('collection', collection);
+    if (imageMode) formData.append('imageMode', imageMode);
 
     const res = await fetch('/generate', { method: 'POST', body: formData });
     const { zip, genId } = await res.json();
@@ -46,6 +48,7 @@ export default function App() {
       <input type="file" onChange={e => setFile(e.target.files[0])} /><br />
       <input type="text" placeholder="Artwork Title" value={title} onChange={e => setTitle(e.target.value)} /><br />
       <input type="text" placeholder="Collection Name" value={collection} onChange={e => setCollection(e.target.value)} /><br />
+      <input type="text" placeholder="Image Mode" value={imageMode} onChange={e => setImageMode(e.target.value)} /><br />
       <button onClick={handleGenerate} disabled={loading}>
         {loading ? 'Generating...' : 'Generate Mockups'}
       </button>


### PR DESCRIPTION
## Summary
- Pass uploaded image data and optional image mode to Replicate predictions
- Send image mode from client form
- Remove temporary uploads after generation completes

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run build` (client)


------
https://chatgpt.com/codex/tasks/task_e_6895589a70e88320899de6d86f578283