### PR TITLE
Decode base64 zip in client

### DIFF
--- a/aurelia-mockup-generator/client/src/App.jsx
+++ b/aurelia-mockup-generator/client/src/App.jsx
@@ -41,7 +41,9 @@ export default function App() {
 
     eventSourceRef.current = connectProgress(genId);
 
-    const blob = await (await fetch(zip)).blob();
+    const b64 = zip.split(',')[1];
+    const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+    const blob = new Blob([bytes], { type: 'application/zip' });
     setDownloadUrl(window.URL.createObjectURL(blob));
 
     eventSourceRef.current?.close();


### PR DESCRIPTION
## Summary
- manually decode base64 ZIP payload into bytes before creating blob in React client

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68955caa806883209a791c7889af702c