### PR TITLE
fix: convert PostCSS config to CommonJS

### DIFF
--- a/aurelia-mockup-generator/client/postcss.config.cjs
+++ b/aurelia-mockup-generator/client/postcss.config.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Summary
- rename client/postcss.config.js to postcss.config.cjs
- export PostCSS config via CommonJS module

## Testing
- `npm run build`
- `docker build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955e3c2b0c8320bfbb0f04b2d7e637