### PR TITLE
Remove hardcoded Replicate environment variables

### DIFF
--- a/aurelia-mockup-generator/Dockerfile
+++ b/aurelia-mockup-generator/Dockerfile
@@ -25,7 +25,8 @@ WORKDIR /app/server
 ENV NODE_ENV=production
 ENV PORT=3000
 # Required environment variables
-ENV REPLICATE_API_TOKEN=""
-ENV REPLICATE_MODEL_VERSION=""
+# Provide these at runtime via `docker run -e` or Docker secrets
+# ENV REPLICATE_API_TOKEN=""
+# ENV REPLICATE_MODEL_VERSION=""
 EXPOSE 3000
 CMD ["node", "index.js"]

--- a/aurelia-mockup-generator/README.md
+++ b/aurelia-mockup-generator/README.md
@@ -1,0 +1,21 @@
+# Aurelia Mockup Generator
+
+This project builds a Docker image for the mockup generator service.
+
+## Runtime environment variables
+
+The image requires the following environment variables at runtime:
+
+- `REPLICATE_API_TOKEN` – API token for the Replicate service.
+- `REPLICATE_MODEL_VERSION` – Model version identifier used by Replicate.
+
+Provide these variables when starting the container, for example:
+
+```bash
+docker run -e REPLICATE_API_TOKEN=your_token \
+           -e REPLICATE_MODEL_VERSION=your_model_version \
+           -p 3000:3000 <image-name>
+```
+
+They can also be supplied using Docker secrets or your orchestration platform's
+secret management features.


### PR DESCRIPTION
## Summary
- Comment out Replicate token and model version ENV directives in Dockerfile
- Add README instructions to supply REPLICATE_API_TOKEN and REPLICATE_MODEL_VERSION at runtime

## Testing
- `docker build -t mockup-generator:latest .` *(fails: command not found: docker)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `npm ci` *(fails: lock file out of sync with package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68955e3dbb28832091ec2a3c16664760